### PR TITLE
Format semantic tags with bold and italic

### DIFF
--- a/src/styles/css/dracula.css
+++ b/src/styles/css/dracula.css
@@ -266,8 +266,8 @@ em {
   color: var(--italic-fg);
 }
 
-b > i,
-i > b {
+:is(b, strong) > :is(i, em),
+:is(i, em) > :is(b, strong) {
   color: var(--bold-italic-fg);
 }
 

--- a/src/styles/css/minimal.css
+++ b/src/styles/css/minimal.css
@@ -275,16 +275,16 @@ a:hover, a:active {
 }
 
 /* -------------------------------------------------- FORMATTING */
-b {
+b, strong {
   color: var(--bold-fg);
 }
 
-i {
+i, em {
   color: var(--italic-fg);
 }
 
-b > i,
-i > b {
+:is(b, strong) > :is(i, em),
+:is(i, em) > :is(b, strong) {
   color: var(--bold-italic-fg);
 }
 

--- a/src/styles/css/nord.css
+++ b/src/styles/css/nord.css
@@ -293,8 +293,8 @@ em {
   color: var(--italic-fg);
 }
 
-b > i,
-i > b {
+:is(b, strong) > :is(i, em),
+:is(i, em) > :is(b, strong) {
   color: var(--bold-italic-fg);
 }
 

--- a/src/styles/scss/dracula.scss
+++ b/src/styles/scss/dracula.scss
@@ -313,16 +313,21 @@ a {
 b,
 strong {
   color: var(--bold-fg);
+
+  > i,
+  > em {
+    color: var(--bold-italic-fg);
+  }
 }
 
 i,
 em {
   color: var(--italic-fg);
-}
 
-b>i,
-i>b {
-  color: var(--bold-italic-fg);
+  > b,
+  > strong {
+    color: var(--bold-italic-fg);
+  }
 }
 
 u {

--- a/src/styles/scss/minimal.scss
+++ b/src/styles/scss/minimal.scss
@@ -318,17 +318,24 @@ a {
 }
 
 /* -------------------------------------------------- FORMATTING */
-b {
+b,
+strong {
   color: var(--bold-fg);
+
+  > i,
+  > em {
+    color: var(--bold-italic-fg);
+  }
 }
 
-i {
+i,
+em {
   color: var(--italic-fg);
-}
 
-b>i,
-i>b {
-  color: var(--bold-italic-fg);
+  > b,
+  > strong {
+    color: var(--bold-italic-fg);
+  }
 }
 
 u {

--- a/src/styles/scss/nord.scss
+++ b/src/styles/scss/nord.scss
@@ -344,16 +344,21 @@ a {
 b,
 strong {
   color: var(--bold-fg);
+
+  > i,
+  > em {
+    color: var(--bold-italic-fg);
+  }
 }
 
 i,
 em {
   color: var(--italic-fg);
-}
 
-b > i,
-i > b {
-  color: var(--bold-italic-fg);
+  > b,
+  > strong {
+    color: var(--bold-italic-fg);
+  }
 }
 
 u {


### PR DESCRIPTION
This PR formats semantic HTML tags `<strong>` and `<em>` as bold and italic.